### PR TITLE
Fixed craftcms/cms requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "~3.0.0-beta.36",
+        "craftcms/cms": "^3.0.0-beta.36",
         "roave/security-advisories": "dev-master",
         "craftcms/plugin-installer": "^1.0.0"
     },


### PR DESCRIPTION
Without this change, the plugin is saying it won’t be compatible with Craft 3.1+, which probably isn’t want you intended.